### PR TITLE
Enable factory injection of a container

### DIFF
--- a/src/NServiceBus.Autofac.Tests/SetUpFixture.cs
+++ b/src/NServiceBus.Autofac.Tests/SetUpFixture.cs
@@ -1,5 +1,6 @@
 ﻿using NServiceBus.ContainerTests;
 using NServiceBus.ObjectBuilder.Autofac;
+using NServiceBus.Settings;
 using NUnit.Framework;
 
 [SetUpFixture]
@@ -8,7 +9,6 @@ public class SetUpFixture
     [SetUp]
     public void Setup()
     {
-        TestContainerBuilder.ConstructBuilder = () => new AutofacObjectBuilder();
+        TestContainerBuilder.ConstructBuilder = () => new AutofacObjectBuilder(new SettingsHolder());
     }
-
 }

--- a/src/NServiceBus.Autofac/AutofacBuilder.cs
+++ b/src/NServiceBus.Autofac/AutofacBuilder.cs
@@ -21,10 +21,10 @@ namespace NServiceBus
 
             if (settings.TryGet("ExistingLifetimeScope", out existingLifetimeScope))
             {
-                return new AutofacObjectBuilder(existingLifetimeScope);
+                return new AutofacObjectBuilder(settings, existingLifetimeScope);
             }
 
-            return new AutofacObjectBuilder();
+            return new AutofacObjectBuilder(settings);
         }
     }
 }

--- a/src/NServiceBus.Autofac/AutofacExtensions.cs
+++ b/src/NServiceBus.Autofac/AutofacExtensions.cs
@@ -1,9 +1,11 @@
 namespace NServiceBus
 {
-    using Container;
+	using System;
+	using Container;
     using global::Autofac;
+	using NServiceBus.Settings;
 
-    /// <summary>
+	/// <summary>
     /// Autofac extension to pass an existing Autofac container instance.
     /// </summary>
     public static class AutofacExtensions
@@ -17,5 +19,16 @@ namespace NServiceBus
         {
             customizations.Settings.Set("ExistingLifetimeScope", lifetimeScope);
         }
-    }
+
+		/// <summary>
+		/// Use the pre-configured Autofac lifetime scope.
+		/// </summary>
+		/// <param name="customizations"></param>
+		/// <param name="factory">The factory that will retrieve the lifetime scope to use.</param>
+		public static void ChildScopeFactory(this ContainerCustomizations customizations,
+			Func<ReadOnlySettings, ILifetimeScope> factory)
+		{
+			customizations.Settings.Set("ChildScopeContainerFactory", factory);
+		}
+	}
 }


### PR DESCRIPTION
Issue: A request sent to a WCF service, which calls `IBus.SendLocal` creates two instances of an object configured as `InstancePerLifetimeScope()`

http://stackoverflow.com/questions/30023217/is-there-a-way-to-pass-a-child-container-into-the-nservicebus-pipeline

With this change I'd be able to inject any container into the outgoing pipeline, making it easy to do this

    var container = CreateDependencyInjectionContainer();
    var busConfig = new BusConfiguration();
    busConfig.UseContainer<AutofacBuilder>(c =>
	{
		c.ExistingLifetimeScope(container);
		c.ChildScopeFactory(_ => AutofacInstanceContext.Current != null
			? AutofacInstanceContext.Current.OperationLifetime
			: null);
	});
