### PR TITLE
Externally owned lifetime scope is no longer disposed

### DIFF
--- a/src/NServiceBus.Autofac.AcceptanceTests/NServiceBus.Autofac.AcceptanceTests.csproj
+++ b/src/NServiceBus.Autofac.AcceptanceTests/NServiceBus.Autofac.AcceptanceTests.csproj
@@ -35,6 +35,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=4.1.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.1.0\lib\net45\Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.6.0.0-rc0001\lib\net452\NServiceBus.AcceptanceTesting.dll</HintPath>
       <Private>True</Private>
@@ -71,6 +75,8 @@
     <Compile Include="DefaultServer.cs" />
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="When_declaring_a_public_property.cs" />
+    <Compile Include="When_using_externally_owned_container.cs" />
+    <Compile Include="ScopeDecorator.cs" />
     <Compile Include="When_setting_properties_explicitly_via_the_container.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NServiceBus.Autofac.AcceptanceTests/ScopeDecorator.cs
+++ b/src/NServiceBus.Autofac.AcceptanceTests/ScopeDecorator.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.Autofac.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using global::Autofac;
+    using global::Autofac.Core;
+    using global::Autofac.Core.Lifetime;
+    using global::Autofac.Core.Resolving;
+
+    class ScopeDecorator : ILifetimeScope
+    {
+        public ScopeDecorator(ILifetimeScope decorated)
+        {
+            this.decorated = decorated;
+        }
+
+        public bool Disposed { get; private set; }
+
+        public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        {
+            return decorated.ResolveComponent(registration, parameters);
+        }
+
+        public IComponentRegistry ComponentRegistry => decorated.ComponentRegistry;
+
+        public void Dispose()
+        {
+            decorated.Dispose();
+            Disposed = true;
+        }
+
+        public ILifetimeScope BeginLifetimeScope()
+        {
+            return decorated.BeginLifetimeScope();
+        }
+
+        public ILifetimeScope BeginLifetimeScope(object tag)
+        {
+            return decorated.BeginLifetimeScope(tag);
+        }
+
+        public ILifetimeScope BeginLifetimeScope(Action<ContainerBuilder> configurationAction)
+        {
+            return decorated.BeginLifetimeScope(configurationAction);
+        }
+
+        public ILifetimeScope BeginLifetimeScope(object tag, Action<ContainerBuilder> configurationAction)
+        {
+            return decorated.BeginLifetimeScope(tag, configurationAction);
+        }
+
+        public IDisposer Disposer => decorated.Disposer;
+
+        public object Tag => decorated.Tag;
+
+        public event EventHandler<LifetimeScopeBeginningEventArgs> ChildLifetimeScopeBeginning
+        {
+            add { decorated.ChildLifetimeScopeBeginning += value; }
+            remove { decorated.ChildLifetimeScopeBeginning -= value; }
+        }
+
+        public event EventHandler<LifetimeScopeEndingEventArgs> CurrentScopeEnding
+        {
+            add { decorated.CurrentScopeEnding += value; }
+            remove { decorated.CurrentScopeEnding -= value; }
+        }
+        public event EventHandler<ResolveOperationBeginningEventArgs> ResolveOperationBeginning
+        {
+            add { decorated.ResolveOperationBeginning += value; }
+            remove { decorated.ResolveOperationBeginning -= value; }
+        }
+
+        private readonly ILifetimeScope decorated;
+    }
+}

--- a/src/NServiceBus.Autofac.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Autofac.AcceptanceTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Autofac" version="4.1.0" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />

--- a/src/NServiceBus.Autofac.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Autofac.Tests/DisposalTests.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.Autofac.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using global::Autofac;
+    using global::Autofac.Core;
+    using global::Autofac.Core.Lifetime;
+    using global::Autofac.Core.Resolving;
+    using NServiceBus.ObjectBuilder.Autofac;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var fakeScope = new FakeLifetimeScope();
+
+            var container = new AutofacObjectBuilder(fakeScope, true);
+            container.Dispose();
+
+            Assert.True(fakeScope.Disposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var fakeScope = new FakeLifetimeScope();
+
+            var container = new AutofacObjectBuilder(fakeScope, false);
+            container.Dispose();
+
+            Assert.False(fakeScope.Disposed);
+        }
+
+        sealed class FakeLifetimeScope : ILifetimeScope
+        {
+            public bool Disposed { get; private set; }
+
+            public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+            {
+                return null;
+            }
+
+            public IComponentRegistry ComponentRegistry { get; }
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public ILifetimeScope BeginLifetimeScope()
+            {
+                return null;
+            }
+
+            public ILifetimeScope BeginLifetimeScope(object tag)
+            {
+                return null;
+            }
+
+            public ILifetimeScope BeginLifetimeScope(Action<ContainerBuilder> configurationAction)
+            {
+                return null;
+            }
+
+            public ILifetimeScope BeginLifetimeScope(object tag, Action<ContainerBuilder> configurationAction)
+            {
+                return null;
+            }
+
+            public IDisposer Disposer { get; }
+            public object Tag { get; }
+            public event EventHandler<LifetimeScopeBeginningEventArgs> ChildLifetimeScopeBeginning;
+            public event EventHandler<LifetimeScopeEndingEventArgs> CurrentScopeEnding;
+            public event EventHandler<ResolveOperationBeginningEventArgs> ResolveOperationBeginning;
+
+            private void OnChildLifetimeScopeBeginning(LifetimeScopeBeginningEventArgs e)
+            {
+                ChildLifetimeScopeBeginning?.Invoke(this, e);
+            }
+
+            private void OnCurrentScopeEnding(LifetimeScopeEndingEventArgs e)
+            {
+                CurrentScopeEnding?.Invoke(this, e);
+            }
+
+            private void OnResolveOperationBeginning(ResolveOperationBeginningEventArgs e)
+            {
+                ResolveOperationBeginning?.Invoke(this, e);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Autofac.Tests/NServiceBus.Autofac.Tests.csproj
+++ b/src/NServiceBus.Autofac.Tests/NServiceBus.Autofac.Tests.csproj
@@ -50,6 +50,10 @@
       <HintPath>..\packages\ApprovalUtilities.3.0.11\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Autofac, Version=4.1.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.1.0\lib\net45\Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
@@ -93,6 +97,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_querying_for_registered_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_registering_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_using_nested_containers.cs" />
+    <Compile Include="DisposalTests.cs" />
     <Compile Include="SetUpFixture.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.Autofac.Tests/packages.config
+++ b/src/NServiceBus.Autofac.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="ApiApprover" version="3.0.1" targetFramework="net452" />
   <package id="ApprovalTests" version="3.0.11" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.11" targetFramework="net452" />
+  <package id="Autofac" version="4.1.0" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.ContainerTests.Sources" version="6.0.0-rc0001" targetFramework="net452" />

--- a/src/NServiceBus.Autofac/AutofacBuilder.cs
+++ b/src/NServiceBus.Autofac/AutofacBuilder.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus
 {
     using Container;
-    using global::Autofac;
+    using Autofac;
     using ObjectBuilder.Autofac;
     using Settings;
 
@@ -17,14 +17,24 @@ namespace NServiceBus
         /// <returns>The new container wrapper.</returns>
         public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
         {
-            ILifetimeScope existingLifetimeScope;
+            LifetimeScopeHolder scopeHolder;
 
-            if (settings.TryGet("ExistingLifetimeScope", out existingLifetimeScope))
+            if (settings.TryGet(out scopeHolder))
             {
-                return new AutofacObjectBuilder(existingLifetimeScope);
+                return new AutofacObjectBuilder(scopeHolder.ExistingLifetimeScope);
             }
 
             return new AutofacObjectBuilder();
+        }
+
+        internal class LifetimeScopeHolder
+        {
+            public LifetimeScopeHolder(ILifetimeScope lifetimeScope)
+            {
+                ExistingLifetimeScope = lifetimeScope;
+            }
+
+            public ILifetimeScope ExistingLifetimeScope { get; }
         }
     }
 }

--- a/src/NServiceBus.Autofac/AutofacExtensions.cs
+++ b/src/NServiceBus.Autofac/AutofacExtensions.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus
 {
     using Container;
-    using global::Autofac;
+    using Autofac;
 
     /// <summary>
     /// Autofac extension to pass an existing Autofac container instance.
@@ -15,7 +15,7 @@ namespace NServiceBus
         /// <param name="lifetimeScope">The existing lifetime scope to use.</param>
         public static void ExistingLifetimeScope(this ContainerCustomizations customizations, ILifetimeScope lifetimeScope)
         {
-            customizations.Settings.Set("ExistingLifetimeScope", lifetimeScope);
+            customizations.Settings.Set<AutofacBuilder.LifetimeScopeHolder>(new AutofacBuilder.LifetimeScopeHolder(lifetimeScope));
         }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/4144

If a user passes us in a kernel instance we will not dispose the llifetime instance. We consider that instance externally owned. This is a behavior breaking change. 

I also had to remove the key access since the SettingsHolder automatically disposes settings values that implement `IDisposable`.