### PR TITLE
Prevent disposing containers that NSB doesn't manage

### DIFF
--- a/src/NServiceBus.Autofac.AcceptanceTests/NServiceBus.Autofac.AcceptanceTests.csproj
+++ b/src/NServiceBus.Autofac.AcceptanceTests/NServiceBus.Autofac.AcceptanceTests.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=4.1.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.1.0\lib\net45\Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.AcceptanceTesting">
       <HintPath>..\packages\NServiceBus.AcceptanceTesting.5.0.0\lib\net45\NServiceBus.AcceptanceTesting.dll</HintPath>
     </Reference>
@@ -159,6 +163,11 @@
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.0.0\Tx\When_sending_within_an_ambient_transaction.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.0.0\Versioning\When_multiple_versions_of_a_message_is_published.cs" />
     <Compile Include="App_Packages\NSB.AcceptanceTests.5.0.0\Volatile\When_sending_to_non_durable_endpoint.cs" />
+    <Compile Include="ScopeDecorator.cs" />
+    <Compile Include="When_using_externally_owned_container.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.Autofac.AcceptanceTests/ScopeDecorator.cs
+++ b/src/NServiceBus.Autofac.AcceptanceTests/ScopeDecorator.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.Autofac.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using global::Autofac;
+    using global::Autofac.Core;
+    using global::Autofac.Core.Lifetime;
+    using global::Autofac.Core.Resolving;
+
+    class ScopeDecorator : ILifetimeScope
+    {
+        public ScopeDecorator(ILifetimeScope decorated)
+        {
+            this.decorated = decorated;
+        }
+
+        public bool Disposed { get; private set; }
+
+        public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        {
+            return decorated.ResolveComponent(registration, parameters);
+        }
+
+        public IComponentRegistry ComponentRegistry => decorated.ComponentRegistry;
+
+        public void Dispose()
+        {
+            decorated.Dispose();
+            Disposed = true;
+        }
+
+        public ILifetimeScope BeginLifetimeScope()
+        {
+            return decorated.BeginLifetimeScope();
+        }
+
+        public ILifetimeScope BeginLifetimeScope(object tag)
+        {
+            return decorated.BeginLifetimeScope(tag);
+        }
+
+        public ILifetimeScope BeginLifetimeScope(Action<ContainerBuilder> configurationAction)
+        {
+            return decorated.BeginLifetimeScope(configurationAction);
+        }
+
+        public ILifetimeScope BeginLifetimeScope(object tag, Action<ContainerBuilder> configurationAction)
+        {
+            return decorated.BeginLifetimeScope(tag, configurationAction);
+        }
+
+        public IDisposer Disposer => decorated.Disposer;
+
+        public object Tag => decorated.Tag;
+
+        public event EventHandler<LifetimeScopeBeginningEventArgs> ChildLifetimeScopeBeginning
+        {
+            add { decorated.ChildLifetimeScopeBeginning += value; }
+            remove { decorated.ChildLifetimeScopeBeginning -= value; }
+        }
+
+        public event EventHandler<LifetimeScopeEndingEventArgs> CurrentScopeEnding
+        {
+            add { decorated.CurrentScopeEnding += value; }
+            remove { decorated.CurrentScopeEnding -= value; }
+        }
+        public event EventHandler<ResolveOperationBeginningEventArgs> ResolveOperationBeginning
+        {
+            add { decorated.ResolveOperationBeginning += value; }
+            remove { decorated.ResolveOperationBeginning -= value; }
+        }
+
+        private readonly ILifetimeScope decorated;
+    }
+}

--- a/src/NServiceBus.Autofac.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Autofac.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.Autofac.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using global::Autofac;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_externally_owned_container : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_shutdown_properly()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(Endpoint.Context.Decorator.Disposed);
+            Assert.DoesNotThrow(() => Endpoint.Context.Scope.Dispose());
+        }
+
+        class Context : ScenarioContext
+        {
+            public ScopeDecorator Decorator { get; set; }
+            public ILifetimeScope Scope { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public static Context Context { get; set; }
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    var container = new ContainerBuilder().Build();
+                    var scopeDecorator = new ScopeDecorator(container);
+
+                    config.UseContainer<AutofacBuilder>(c => c.ExistingLifetimeScope(scopeDecorator));
+
+                    Context.Decorator = scopeDecorator;
+                    Context.Scope = container;
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Autofac.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Autofac.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Autofac.AcceptanceTests
 {
-    using System.Threading.Tasks;
     using global::Autofac;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests;

--- a/src/NServiceBus.Autofac.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Autofac.AcceptanceTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Autofac" version="4.1.0" targetFramework="net45" />
   <package id="NServiceBus" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTesting" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.AcceptanceTests.Sources" version="5.0.0" targetFramework="net45" />

--- a/src/NServiceBus.Autofac.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Autofac.Tests/DisposalTests.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.Autofac.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using global::Autofac;
+    using global::Autofac.Core;
+    using global::Autofac.Core.Lifetime;
+    using global::Autofac.Core.Resolving;
+    using NServiceBus.ObjectBuilder.Autofac;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var fakeScope = new FakeLifetimeScope();
+
+            var container = new AutofacObjectBuilder(fakeScope, true);
+            container.Dispose();
+
+            Assert.True(fakeScope.Disposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var fakeScope = new FakeLifetimeScope();
+
+            var container = new AutofacObjectBuilder(fakeScope, false);
+            container.Dispose();
+
+            Assert.False(fakeScope.Disposed);
+        }
+
+        sealed class FakeLifetimeScope : ILifetimeScope
+        {
+            public bool Disposed { get; private set; }
+
+            public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+            {
+                return null;
+            }
+
+            public IComponentRegistry ComponentRegistry { get; }
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public ILifetimeScope BeginLifetimeScope()
+            {
+                return null;
+            }
+
+            public ILifetimeScope BeginLifetimeScope(object tag)
+            {
+                return null;
+            }
+
+            public ILifetimeScope BeginLifetimeScope(Action<ContainerBuilder> configurationAction)
+            {
+                return null;
+            }
+
+            public ILifetimeScope BeginLifetimeScope(object tag, Action<ContainerBuilder> configurationAction)
+            {
+                return null;
+            }
+
+            public IDisposer Disposer { get; }
+            public object Tag { get; }
+            public event EventHandler<LifetimeScopeBeginningEventArgs> ChildLifetimeScopeBeginning;
+            public event EventHandler<LifetimeScopeEndingEventArgs> CurrentScopeEnding;
+            public event EventHandler<ResolveOperationBeginningEventArgs> ResolveOperationBeginning;
+
+            private void OnChildLifetimeScopeBeginning(LifetimeScopeBeginningEventArgs e)
+            {
+                ChildLifetimeScopeBeginning?.Invoke(this, e);
+            }
+
+            private void OnCurrentScopeEnding(LifetimeScopeEndingEventArgs e)
+            {
+                CurrentScopeEnding?.Invoke(this, e);
+            }
+
+            private void OnResolveOperationBeginning(ResolveOperationBeginningEventArgs e)
+            {
+                ResolveOperationBeginning?.Invoke(this, e);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Autofac.Tests/NServiceBus.Autofac.Tests.csproj
+++ b/src/NServiceBus.Autofac.Tests/NServiceBus.Autofac.Tests.csproj
@@ -33,6 +33,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac, Version=4.1.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.1.0\lib\net45\Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Core">
       <HintPath>..\packages\NServiceBus.5.0.0\lib\net45\NServiceBus.Core.dll</HintPath>
     </Reference>
@@ -56,6 +60,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.5.0.0\When_registering_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.5.0.0\When_releasing_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.5.0.0\When_using_nested_containers.cs" />
+    <Compile Include="DisposalTests.cs" />
     <Compile Include="SetUpFixture.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -66,6 +71,9 @@
       <Project>{73EC4EBE-826D-4A0A-8837-51D3458FC2A8}</Project>
       <Name>NServiceBus.Autofac</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.Autofac.Tests/packages.config
+++ b/src/NServiceBus.Autofac.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Autofac" version="4.1.0" targetFramework="net45" />
   <package id="NServiceBus" version="5.0.0" targetFramework="net45" />
   <package id="NServiceBus.ContainerTests.Sources" version="5.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />

--- a/src/NServiceBus.Autofac/AutofacBuilder.cs
+++ b/src/NServiceBus.Autofac/AutofacBuilder.cs
@@ -17,14 +17,24 @@ namespace NServiceBus
         /// <returns>The new container wrapper.</returns>
         public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
         {
-            ILifetimeScope existingLifetimeScope;
+            LifetimeScopeHolder scopeHolder;
 
-            if (settings.TryGet("ExistingLifetimeScope", out existingLifetimeScope))
+            if (settings.TryGet(out scopeHolder))
             {
-                return new AutofacObjectBuilder(existingLifetimeScope);
+                return new AutofacObjectBuilder(scopeHolder.ExistingLifetimeScope);
             }
 
             return new AutofacObjectBuilder();
+        }
+
+        internal class LifetimeScopeHolder
+        {
+            public LifetimeScopeHolder(ILifetimeScope lifetimeScope)
+            {
+                ExistingLifetimeScope = lifetimeScope;
+            }
+
+            public ILifetimeScope ExistingLifetimeScope { get; }
         }
     }
 }

--- a/src/NServiceBus.Autofac/AutofacExtensions.cs
+++ b/src/NServiceBus.Autofac/AutofacExtensions.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus
 {
     using Container;
-    using global::Autofac;
+    using Autofac;
 
     /// <summary>
     /// Autofac extension to pass an existing Autofac container instance.
@@ -15,7 +15,7 @@ namespace NServiceBus
         /// <param name="lifetimeScope">The existing lifetime scope to use.</param>
         public static void ExistingLifetimeScope(this ContainerCustomizations customizations, ILifetimeScope lifetimeScope)
         {
-            customizations.Settings.Set("ExistingLifetimeScope", lifetimeScope);
+            customizations.Settings.Set<AutofacBuilder.LifetimeScopeHolder>(new AutofacBuilder.LifetimeScopeHolder(lifetimeScope));
         }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/4144

## Who's affected

All users providing an externally created container into the endpoint configuration.

## Symptions

If the externally owned container is disposed all instances marked as `IDisposable `that are registered by NServiceBus will be double disposed which can lead to unwanted side effects and endpoints not being able to properly shut down.

Ping @Particular/container-maintainers 