### PR TITLE
Remove the Parent container scope restriction

### DIFF
--- a/src/NServiceBus.Autofac.AcceptanceTests/When_declaring_a_public_property.cs
+++ b/src/NServiceBus.Autofac.AcceptanceTests/When_declaring_a_public_property.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Autofac.AcceptanceTests
 {
     using System.Threading.Tasks;
-    using NServiceBus.AcceptanceTesting;
+    using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;

--- a/src/NServiceBus.Autofac.AcceptanceTests/When_setting_properties_explicitly_via_the_container.cs
+++ b/src/NServiceBus.Autofac.AcceptanceTests/When_setting_properties_explicitly_via_the_container.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Autofac.AcceptanceTests
 {
     using System.Threading.Tasks;
-    using NServiceBus.AcceptanceTesting;
+    using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;

--- a/src/NServiceBus.Autofac.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.Autofac.AcceptanceTests/When_using_externally_owned_container.cs
@@ -2,7 +2,7 @@
 {
     using System.Threading.Tasks;
     using global::Autofac;
-    using NServiceBus.AcceptanceTesting;
+    using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;

--- a/src/NServiceBus.Autofac.Tests/DisposalTests.cs
+++ b/src/NServiceBus.Autofac.Tests/DisposalTests.cs
@@ -6,7 +6,7 @@
     using global::Autofac.Core;
     using global::Autofac.Core.Lifetime;
     using global::Autofac.Core.Resolving;
-    using NServiceBus.ObjectBuilder.Autofac;
+    using ObjectBuilder.Autofac;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/NServiceBus.Autofac/AutofacObjectBuilder.cs
+++ b/src/NServiceBus.Autofac/AutofacObjectBuilder.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.ObjectBuilder.Autofac
     using global::Autofac;
     using global::Autofac.Builder;
     using global::Autofac.Core;
-    using global::Autofac.Core.Lifetime;
 
     class AutofacObjectBuilder : Common.IContainer
     {

--- a/src/NServiceBus.Autofac/AutofacObjectBuilder.cs
+++ b/src/NServiceBus.Autofac/AutofacObjectBuilder.cs
@@ -61,8 +61,6 @@ namespace NServiceBus.ObjectBuilder.Autofac
 
         public void Configure(Type component, DependencyLifecycle dependencyLifecycle)
         {
-            EnforceNotInChildContainer();
-
             var registration = GetComponentRegistration(component);
 
             if (registration != null)
@@ -81,8 +79,6 @@ namespace NServiceBus.ObjectBuilder.Autofac
 
         public void Configure<T>(Func<T> componentFactory, DependencyLifecycle dependencyLifecycle)
         {
-            EnforceNotInChildContainer();
-
             var registration = GetComponentRegistration(typeof(T));
 
             if (registration != null)
@@ -101,8 +97,6 @@ namespace NServiceBus.ObjectBuilder.Autofac
 
         public void RegisterSingleton(Type lookupType, object instance)
         {
-            EnforceNotInChildContainer();
-
             var builder = new ContainerBuilder();
             builder.RegisterInstance(instance).As(lookupType).PropertiesAutowired();
             builder.Update(container.ComponentRegistry);
@@ -170,14 +164,6 @@ namespace NServiceBus.ObjectBuilder.Autofac
         static IEnumerable<object> ResolveAll(IComponentContext container, Type componentType)
         {
             return container.Resolve(typeof(IEnumerable<>).MakeGenericType(componentType)) as IEnumerable<object>;
-        }
-
-        private void EnforceNotInChildContainer()
-        {
-            if ((container as LifetimeScope)?.ParentLifetimeScope != null)
-            {
-                throw new InvalidOperationException("Can't perform configurations on child containers");
-            }
         }
     }
 }


### PR DESCRIPTION
## Background

In V5 users were able to provide any `ILifetimeScope` to the IBus configuration and in V6 we appear to have restricted this lifetimescope to a `ParentLifetimeScope` only.

## Who's affected

* Any user trying to use a child Lifetime Scope with Autofac and NServiceBus V6

## Symptoms

The application will compile, but will receive an `InvalidOperationException` at runtime due to not using a `ParentLifetimeScope`.

@Particular/container-maintainers @Particular/nservicebus-maintainers Please validate that there is no reason for this restriction. Alternatively, if there is a requirement for this, then we should have a test included in the core to enforce this behaviour.